### PR TITLE
fix: double duplicate public_room on html

### DIFF
--- a/public/room_selection.html
+++ b/public/room_selection.html
@@ -51,9 +51,6 @@
 
 
 		<div id="all_rooms_by_username">
-			<div class="room_post">
-				<div class="room_text">public_room</div>
-			</div>
 		</div>
 
 		<div>


### PR DESCRIPTION
# Summary
1. fix: double duplicate public_room shown on room selection page.